### PR TITLE
Update sethostname.service to run before avahi-daemon

### DIFF
--- a/riaps-install/etc/systemd/system/sethostname.service
+++ b/riaps-install/etc/systemd/system/sethostname.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Set hostname based on Ethernet MAC address
-Before=network-online.target
-Requires=network-online.target
+Before=avahi-daemon.service
+Requires=avahi-daemon.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This fixes the issue of needed to reboot a BBB after its first boot in order to properly resolve mDNS names.